### PR TITLE
Create GitHub Actions Testing Workflow 

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,7 +1,13 @@
 # Modified from https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,32 @@
+# Modified from https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r cpu_dev_requirements.txt
+
+      - name: Test with pytest
+        run: |
+          pytest


### PR DESCRIPTION
Attempting this PR again from a branch inside wilburnlab/collage. The workflow did not run on a PR from alope107/collage.

- Creates a workflow that runs tests for all pull requests against or pushes to main.
- Tests against Python 3.10 on the CPU. GPU version is not tested. May consider adding 3.11 in the near future.
- Currently main is not a protected branch, but once this is merged in main should be made protected.
- Does not currently do any dependency caching beyond GitHub defaults. Potential area for improvement in the future, but as the workflow runs in <1 min it is currently not a concern.
- Does not enforce any linting rules. Another area for future improvement