### PR TITLE
Update FASTA writing logic.

### DIFF
--- a/collage/fasta.py
+++ b/collage/fasta.py
@@ -66,23 +66,24 @@ def parse_fasta(file_data: TextIO, first_word: bool):
     return seq_dict
 
 
+def to_fasta(seq_dict: dict) -> str:
+    '''
+    Converts a sequence dictionary to a string in the FASTA format.
+    Lines are separated with UNIX-stye line endings and a trailing newline
+    is included.
+    '''
+    return '\n'.join(f'>{name}\n{seq}' for name, seq in seq_dict.items()) + '\n'
+
+
 def write_fasta(seq_dict: dict,
-                file_name: str,
+                file_name: Path | str,
                 append: bool = True) -> None:
     '''
     Write a sequence dictionary to FASTA file, defaults to append rather than overwrite.
     In append mode, will create a new file first if it doesn't already exist
     '''
 
-    if append == False:  # overwrite mode
-        write_mode = 'w'
-    else:  # append mode
-        write_mode = 'a' if os.path.isfile(file_name) else 'w'
+    write_mode = 'a+' if append else 'w'
 
-    file_out = open(file_name, write_mode)
-
-    for name, seq in seq_dict.items():
-        file_out.write('>' + name + '\n' + seq + '\n')
-
-    file_out.close()
-    return None
+    with open(file_name, write_mode) as f:
+        f.write(to_fasta(seq_dict))

--- a/collage/generator.py
+++ b/collage/generator.py
@@ -76,6 +76,17 @@ def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100):
     return current_seqs
 
 
+def seq_scores_to_seq_dict(seq_scores):
+    '''
+    Takes a dictionary of form {dna_sequence : negLL}
+    and transforms it to {sequence_description : dna_sequence}
+    '''
+    return {
+        f"seq{i}: negLL: {negLL}": seq
+        for i, (seq, negLL) in enumerate(seq_scores.items())
+    }
+
+
 def seq_scorer(model, cds, gen_size=500):
 
     s_codons = re.findall('...', cds)

--- a/generate.py
+++ b/generate.py
@@ -5,8 +5,8 @@ import argparse
 from pathlib import Path
 import sys
 
-from collage.fasta import read_fasta
-from collage.generator import beam_generator
+from collage.fasta import read_fasta, write_fasta
+from collage.generator import beam_generator, seq_scores_to_seq_dict
 from collage.model import initialize_collage_model
 
 
@@ -56,12 +56,10 @@ def predict_and_save(input_path, weights_path, output_path, beam_size, gpu):
     # TODO(auberon): Make predicitions for multiple proteins?
     first_protein = list(proteins.values())[0]
     model = initialize_collage_model(weights_path, gpu)
-    predictions = beam_generator(model, first_protein, max_seqs=beam_size)
+    negLLs = beam_generator(model, first_protein, max_seqs=beam_size)
+    seq_dict = seq_scores_to_seq_dict(negLLs)
 
-    with open(output_path, 'w') as file:
-        file.write(str(predictions))
-
-    print(predictions)
+    write_fasta(seq_dict, output_path, False)
 
 
 def main():

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
 from typing import Dict
-from collage.fasta import FileContentsError, read_fasta
+from collage.fasta import FileContentsError, read_fasta, to_fasta
 
 from pytest_mock import MockFixture
 
@@ -10,19 +10,25 @@ from pytest_mock import MockFixture
 
 
 @pytest.fixture
-def tiny_fasta_file_contents(mocker: MockFixture):
-    '''A mock FASTA file with 3 artificial DNA sequences'''
-    return mocker.mock_open(read_data='''>sp|P00968|CARB_ECOLI
+def tiny_fasta_data():
+    '''A mock FASTA data with 3 artificial DNA sequences'''
+    return '''>sp|P00968|CARB_ECOLI
 GATTACA
 >sp|P02929|TONB_ECOLI
 TAGACAT
 >sp|P04982|RBSD_ECOLI
 GAGAGAG
-''')
+'''
 
 
 @pytest.fixture
-def tiny_fasta_seq_dict() -> Dict[str, str]:
+def tiny_fasta_file(mocker: MockFixture, tiny_fasta_data):
+    '''A mock FASTA file with 3 artificial DNA sequences'''
+    return mocker.mock_open(read_data=tiny_fasta_data)
+
+
+@pytest.fixture
+def tiny_seq_dict() -> Dict[str, str]:
     '''
     A sequence dictionary that corresponds to `tiny_fasta_file_contents`
     Keys are the names, values are the sequences.
@@ -36,33 +42,33 @@ def tiny_fasta_seq_dict() -> Dict[str, str]:
 
 
 def test_read_fasta_creates_valid_seq_dict_for_unzipped_tiny_data(
-        tiny_fasta_file_contents,
-        tiny_fasta_seq_dict: Dict[str, str],
+        tiny_fasta_file,
+        tiny_seq_dict: Dict[str, str],
         mocker: MockFixture):
 
-    mocker.patch('builtins.open', tiny_fasta_file_contents)
+    mocker.patch('builtins.open', tiny_fasta_file)
     actual = read_fasta('tiny.fasta', True)
-    assert tiny_fasta_seq_dict == actual
+    assert tiny_seq_dict == actual
 
 
 def test_read_fasta_creates_valid_seq_dict_for_zipped_tiny_data(
-        tiny_fasta_file_contents,
-        tiny_fasta_seq_dict: Dict[str, str],
+        tiny_fasta_file,
+        tiny_seq_dict: Dict[str, str],
         mocker: MockFixture):
 
-    mocker.patch('gzip.open', tiny_fasta_file_contents)
+    mocker.patch('gzip.open', tiny_fasta_file)
     actual = read_fasta('tiny.fasta.gz', True)
-    assert tiny_fasta_seq_dict == actual
+    assert tiny_seq_dict == actual
 
 
 def test_read_fasta_works_with_path_object(
-        tiny_fasta_file_contents,
-        tiny_fasta_seq_dict: Dict[str, str],
+        tiny_fasta_file,
+        tiny_seq_dict: Dict[str, str],
         mocker: MockFixture):
 
-    mocker.patch('gzip.open', tiny_fasta_file_contents)
+    mocker.patch('gzip.open', tiny_fasta_file)
     actual = read_fasta(Path('tiny.fast.gz'), True)
-    assert tiny_fasta_seq_dict == actual
+    assert tiny_seq_dict == actual
 
 
 def test_read_empty_fasta_raises_FileContentsError(mocker: MockFixture):
@@ -73,3 +79,7 @@ def test_read_empty_fasta_raises_FileContentsError(mocker: MockFixture):
         read_fasta('empty.fasta', True)
 
     assert 'empty.fasta' in str(e.value)
+
+
+def test_to_fasta_creates_correct_fasta_data_from_seq_dict(tiny_fasta_data, tiny_seq_dict):
+    assert to_fasta(tiny_seq_dict) == tiny_fasta_data


### PR DESCRIPTION
Refactor write_fasta and update fasta tests.
- Separate data creation logic from file writing logic.

- Better file handling.

- Rename/refactor fasta test fixtures.

- Add happy-path test for to_fasta.

Add function to transform negLL dict.
- Adds function for transforming output of beam_generator into something
  that can be written into a FASTA.

Have generator script output FASTA.
- Have generator script output a FASTA instead of a score dictionary.