### PR TITLE
Add check_gc option to generator.

### DIFF
--- a/collage/generator.py
+++ b/collage/generator.py
@@ -22,7 +22,7 @@ def gc_100_check(seq):
     return np.any(exceptions)
 
 
-def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100):
+def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100, check_gc=False):
     assert len(
         pre_sequence) % 3 == 0, 'Start sequence length is not a multiple of 3'
 
@@ -66,7 +66,7 @@ def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100):
             codon_logL = dict([(c, l) for c, l in zip(
                 CODONS, logLs[j]) if np.isfinite(l)])
             for c in codon_logL:
-                if gc_100_check(seq + c):
+                if check_gc and gc_100_check(seq + c):
                     continue  # Avoid >65% GC
                 candidate_seqs[seq + c] = current_seqs[seq] + codon_logL[c]
 

--- a/generate.py
+++ b/generate.py
@@ -34,13 +34,16 @@ def parse_args(args: list):
     parser.add_argument('--gpu',
                         action='store_true',
                         help='Use GPU (CUDA) for CoLLAGE training')
+    parser.add_argument('--check_gc',
+                        action='store_true',
+                        help='Whether to filter out candidate sequences that have >65% GC content')
 
     return parser.parse_args(args)
 
 # TODO(auberon) Move this inside package?
 
 
-def predict_and_save(input_path, weights_path, output_path, beam_size, gpu):
+def predict_and_save(input_path, weights_path, output_path, beam_size, gpu, check_gc):
     '''
     Uses given model weights to predict the first protein specified in a given FASTA
     and saves the results to a given file location.
@@ -56,7 +59,7 @@ def predict_and_save(input_path, weights_path, output_path, beam_size, gpu):
     # TODO(auberon): Make predicitions for multiple proteins?
     first_protein = list(proteins.values())[0]
     model = initialize_collage_model(weights_path, gpu)
-    negLLs = beam_generator(model, first_protein, max_seqs=beam_size)
+    negLLs = beam_generator(model, first_protein, max_seqs=beam_size, check_gc=check_gc)
     seq_dict = seq_scores_to_seq_dict(negLLs)
 
     write_fasta(seq_dict, output_path, False)


### PR DESCRIPTION
- Add option --check_gc to generator script. By default it is not included and sequences will not be filtered by the GC check.