### PR TITLE
Fix bugs in gc_100_check.

### DIFF
--- a/collage/generator.py
+++ b/collage/generator.py
@@ -11,28 +11,28 @@ from collage.utils import prot_to_coded
 from collage.reference_data import RESIDUE_TO_INT, CODON_TO_INT, CODONS
 
 
-def exceeds_gc(seq: Iterable[str], window_size: int = 100, max_fraction: float = .65):
+def exceeds_gc(seq: Iterable[str], window_size: int = 100, fraction: float = .65):
     '''Checks whether the GC fraction heuristic is violated in a sequence.
 
     This function returns True if any subsequence of the given size (window_size) within
-    the input sequence (seq) has a GC content exceeding the specified
-    maximum fraction (max_fraction). 
+    the input sequence (seq) has a GC content at or above the specified
+    maximum fraction (fraction). 
 
     Parameters:
     - seq (Iterable[str]): The input sequence of nucleotide bases (strings 'A', 'T', 'G', 'C').
     - window_size (int, optional): The size of the sliding window to check for GC content. 
       Defaults to 100.
-    - max_fraction (float, optional): The maximum allowed fraction of G or C bases within
-      any window. Defaults to 0.65.
+    - fraction (float, optional): The fraction of G or C bases within any window at or above which
+      will be considered excessive. Defaults to 0.65.
 
     Returns:
     - bool: True if any subsequence of the specified window_size has a GC fraction greater
-      than max_fraction, otherwise False.
+      than or equal to fraction, otherwise False.
 
     Special Case:
     If the sequence length is less than the window_size, the function checks if it is 
     impossible for the sequence to meet the constraint even when padded. For example,
-    with a window_size of 6 and a max_fraction of 0.5, the sequence 'GCGC' would return 
+    with a window_size of 6 and a fraction of 0.5, the sequence 'GCGC' would return 
     True because regardless of the additional two bases appended it cannot meet the 
     required fraction for the window size.
 
@@ -40,14 +40,14 @@ def exceeds_gc(seq: Iterable[str], window_size: int = 100, max_fraction: float =
     due to high GC content.
 
     '''
-    max_count = ceil(window_size * max_fraction)
+    max_count = ceil(window_size * fraction)
     count = 0
 
     for i in range(len(seq)):
         count += int(seq[i] in 'GC')
         if i >= window_size:
             count -= int(seq[i - window_size] in 'GC')
-        if count > max_count:
+        if count >= max_count:
             return True
 
     return False

--- a/collage/generator.py
+++ b/collage/generator.py
@@ -1,5 +1,8 @@
 
+from math import ceil
+from collections.abc import Iterable
 import re
+
 import numpy as np
 import torch
 
@@ -8,18 +11,46 @@ from collage.utils import prot_to_coded
 from collage.reference_data import RESIDUE_TO_INT, CODON_TO_INT, CODONS
 
 
-# Let's write a test beam generator function
+def exceeds_gc(seq: Iterable[str], window_size: int = 100, max_fraction: float = .65):
+    '''Checks whether the GC fraction heuristic is violated in a sequence.
 
-current_species = ['Ecoli_K12']
+    This function returns True if any subsequence of the given size (window_size) within
+    the input sequence (seq) has a GC content exceeding the specified
+    maximum fraction (max_fraction). 
 
+    Parameters:
+    - seq (Iterable[str]): The input sequence of nucleotide bases (strings 'A', 'T', 'G', 'C').
+    - window_size (int, optional): The size of the sliding window to check for GC content. 
+      Defaults to 100.
+    - max_fraction (float, optional): The maximum allowed fraction of G or C bases within
+      any window. Defaults to 0.65.
 
-def gc_100_check(seq):
-    # Convert the sequence to GC code
-    gc = [b in ['C', 'G'] for b in seq]
-    slices = [gc[i: i + 100] for i in range(0, len(gc), 100)]
-    percents = [np.mean(s) for s in slices]
-    exceptions = [p >= 0.65 for p in percents]
-    return np.any(exceptions)
+    Returns:
+    - bool: True if any subsequence of the specified window_size has a GC fraction greater
+      than max_fraction, otherwise False.
+
+    Special Case:
+    If the sequence length is less than the window_size, the function checks if it is 
+    impossible for the sequence to meet the constraint even when padded. For example,
+    with a window_size of 6 and a max_fraction of 0.5, the sequence 'GCGC' would return 
+    True because regardless of the additional two bases appended it cannot meet the 
+    required fraction for the window size.
+
+    This heuristic is intended to flag sequences that may be challenging to synthesize
+    due to high GC content.
+
+    '''
+    max_count = ceil(window_size * max_fraction)
+    count = 0
+
+    for i in range(len(seq)):
+        count += int(seq[i] in 'GC')
+        if i >= window_size:
+            count -= int(seq[i - window_size] in 'GC')
+        if count > max_count:
+            return True
+
+    return False
 
 
 def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100, check_gc=False):
@@ -66,7 +97,7 @@ def beam_generator(model, prot, pre_sequence='', gen_size=500, max_seqs=100, che
             codon_logL = dict([(c, l) for c, l in zip(
                 CODONS, logLs[j]) if np.isfinite(l)])
             for c in codon_logL:
-                if check_gc and gc_100_check(seq + c):
+                if check_gc and exceeds_gc(seq + c):
                     continue  # Avoid >65% GC
                 candidate_seqs[seq + c] = current_seqs[seq] + codon_logL[c]
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -47,9 +47,9 @@ def test_end_to_end_training_and_generation(tmp_path, ecoli10_path):
 
     model.load_state_dict(state_dict)
 
-    protein = '.PASTA'
+    protein = 'PASTA'
 
-    seq_scores = beam_generator(model, protein)
+    seq_scores = beam_generator(model, protein, check_gc=True)
     seq_dict = seq_scores_to_seq_dict(seq_scores)
 
     write_fasta(seq_dict, output_file)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -15,36 +15,36 @@ def test_exceeds_gc_triggered_if_impossible_to_extend_to_valid_sequence():
     # With the given sequence it's impossible to get below a fraction of .75
     # for a window size of 4. This exceeds the max_fraction of .66
     seq = 'GCC'
-    assert exceeds_gc(seq, window_size=4, max_fraction=.66)
+    assert exceeds_gc(seq, window_size=4, fraction=.66)
 
 
 def test_exceeds_gc_not_triggered_if_possible_to_extend_to_valid_sequence():
     # With the given sequence it is possible to get as low of a fraction of .3
     # for a window size of 10. This does not exceed the max_fraction of .66
     seq = 'GCC'
-    assert not exceeds_gc(seq, window_size=10, max_fraction=.66)
+    assert not exceeds_gc(seq, window_size=10, fraction=.66)
 
 
 def test_exceeds_gc_not_triggered_with_valid_sequence_matching_window_size():
     seq = 'TAGCAT'
-    assert not exceeds_gc(seq, window_size=6, max_fraction=.5)
+    assert not exceeds_gc(seq, window_size=6, fraction=.5)
 
 
 def test_exceeds_gc_triggered_with_excessive_sequence_matching_window_size():
     seq = 'CCGCAT'
-    assert exceeds_gc(seq, window_size=6, max_fraction=.5)
+    assert exceeds_gc(seq, window_size=6, fraction=.5)
 
 
 def test_exceeds_gc_triggered_with_final_window_violating():
     seq = 'AAATGGG'
-    assert exceeds_gc(seq, window_size=3, max_fraction=.8)
+    assert exceeds_gc(seq, window_size=3, fraction=.8)
 
 
 def test_exceeds_gc_triggered_with_middle_window_violating():
     seq = 'AAGGGTA'
-    assert exceeds_gc(seq, window_size=3, max_fraction=.8)
+    assert exceeds_gc(seq, window_size=3, fraction=.8)
 
 
 def test_exceeds_gc_triggered_with_first_window_violating():
     seq = 'GGGTAAA'
-    assert exceeds_gc(seq, window_size=3, max_fraction=.8)
+    assert exceeds_gc(seq, window_size=3, fraction=.8)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,50 @@
+from collage.generator import exceeds_gc
+
+
+def test_exceeds_gc_not_triggered_on_sequence_with_no_gc():
+    seq = 'AT' * 300
+    assert not exceeds_gc(seq)
+
+
+def test_exceeds_gc_triggered_on_sequence_with_only_gc():
+    seq = 'GC' * 300
+    assert exceeds_gc(seq)
+
+
+def test_exceeds_gc_triggered_if_impossible_to_extend_to_valid_sequence():
+    # With the given sequence it's impossible to get below a fraction of .75
+    # for a window size of 4. This exceeds the max_fraction of .66
+    seq = 'GCC'
+    assert exceeds_gc(seq, window_size=4, max_fraction=.66)
+
+
+def test_exceeds_gc_not_triggered_if_possible_to_extend_to_valid_sequence():
+    # With the given sequence it is possible to get as low of a fraction of .3
+    # for a window size of 10. This does not exceed the max_fraction of .66
+    seq = 'GCC'
+    assert not exceeds_gc(seq, window_size=10, max_fraction=.66)
+
+
+def test_exceeds_gc_not_triggered_with_valid_sequence_matching_window_size():
+    seq = 'TAGCAT'
+    assert not exceeds_gc(seq, window_size=6, max_fraction=.5)
+
+
+def test_exceeds_gc_triggered_with_excessive_sequence_matching_window_size():
+    seq = 'CCGCAT'
+    assert exceeds_gc(seq, window_size=6, max_fraction=.5)
+
+
+def test_exceeds_gc_triggered_with_final_window_violating():
+    seq = 'AAATGGG'
+    assert exceeds_gc(seq, window_size=3, max_fraction=.8)
+
+
+def test_exceeds_gc_triggered_with_middle_window_violating():
+    seq = 'AAGGGTA'
+    assert exceeds_gc(seq, window_size=3, max_fraction=.8)
+
+
+def test_exceeds_gc_triggered_with_first_window_violating():
+    seq = 'GGGTAAA'
+    assert exceeds_gc(seq, window_size=3, max_fraction=.8)


### PR DESCRIPTION
Resolves #24 

- Fixes bugs where sequences shorter than 100 were filtered too strictly.

- FIxes bugs where window did not slide across sequence when checking GC content.

- Renames gc_100_check to exceeds_gc.

- Makes window size and max_fraction configurable for the function. Will possibly expose these options to the generator command line tool later.