### PR TITLE
Test 2 residue sequence in beam generator.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def mock_collage_model() -> MagicMock:
 def mock_lls() -> Dict[int, torch.FloatTensor]:
     '''Returns a dictionary of amino acid strings to mock log likelihoods.
 
-    Each value is a tensor of length 66 (64 possible residues + 2 special tags).
+    Each value is a tensor of length 65 (64 possible residues + 1 special tag).
     The corresponding index for each impossible codon will be -inf, and each possible
     codon will have an arbitrary (but consistent) LL.'''
 
@@ -54,6 +54,6 @@ def mock_lls() -> Dict[int, torch.FloatTensor]:
             else:
                 weights.append(float('-inf'))
 
-        mock_data[INT_TO_RESIDUE[residue_int]] = torch.tensor(weights)
+        mock_data[INT_TO_RESIDUE[residue_int]] = weights
 
     return mock_data

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -5,16 +5,58 @@ from collage.generator import exceeds_gc, beam_generator
 
 def test_beam_generator_one_residue_protein(mock_collage_model, mock_lls):
     '''
-    Test that the correct sequences are generated for a sequence that only has a single
+    Test that the correct sequences are generated for a "protein" that only has a single
     residue: P.
     '''
 
-    mock_collage_model.side_effect = [mock_lls['P'].view(1, 1, 65)]
+    # Mock likelihoods across all 65 tokens for P
+    P = mock_lls['P']
+
+    # Mock response for the first call to the model
+    # Dimensions (1, 1, 65) (1 candidate sequence with 1 residue being predicted across 65 possible tokens)
+    lls = torch.tensor([
+                        [P]
+                       ])
+
+    # Set only a single mock response because the model should only be called once for a sequence length of 1
+    mock_collage_model.side_effect = [lls]
 
     res = beam_generator(mock_collage_model, 'P', '', gen_size=5, max_seqs=5)
 
     # The valid sequences should be the valid codons for 'P'
     assert set(res.keys()) == set(['CCT', 'CCC', 'CCA', 'CCG'])
+
+def test_beam_generator_two_residue_protein(mock_collage_model, mock_lls):
+    '''
+    Test that the correct sequences are generated for a "protein" that has two
+    residues: PD
+    '''
+
+    # Mock likelihoods across all 65 tokens for P and D residues
+    P, D = mock_lls['P'], mock_lls['D']
+
+    # Mock response for the first call to the model (predicting P codon)
+    # Dimensions (1, 1, 65) (1 candidate sequence with 1 residue being predicted across 65 possible tokens)
+    lls1 = torch.tensor([[P]])
+
+    # Mock response for the second call to the model (predicting P and D codon)
+    # Dimensions (4, 2, 65) (4 candidate sequence with 2 residues being predicted across 65 possible tokens)
+    # There are 4 candidate sequences because there are 4 possible codons for P
+    lls2 = torch.tensor([[P, D],
+                         [P, D],
+                         [P, D],
+                         [P, D]])
+
+    # Mock responses for each call to the model
+    mock_collage_model.side_effect = [lls1, lls2]
+
+    res = beam_generator(mock_collage_model, 'PD', '', gen_size=10, max_seqs=10)
+
+    # The valid sequences should be the valid codons for 'PD'
+    assert set(res.keys()) == set(['CCTGAC', 'CCCGAC', 'CCAGAC', 'CCGGAC',
+                                   'CCTGAT', 'CCCGAT', 'CCAGAT', 'CCGGAT'])
+    
+    # TODO(auberon): Verify weights are properly calculated and worst candidates are evicted
 
 
 def test_exceeds_gc_not_triggered_on_sequence_with_no_gc():


### PR DESCRIPTION
- Tests that two residues are properly handled by the beam generator.

- Made mock responses from model in test more explicit.

- Modified mock_lls to return lists instead of tensors.

- Fixed documentation error on the model forward method.